### PR TITLE
Adding Share Donation CTA

### DIFF
--- a/src/components/page-donate/page-donate.scss
+++ b/src/components/page-donate/page-donate.scss
@@ -103,4 +103,39 @@ page-donate {
     opacity: 0;
     cursor: default;
   }
+
+  #share-donation {
+    cursor: pointer;
+    color: #fff;
+    background-color: $blue2;
+    border: 2px solid darken($blue2, 10%);
+
+    &:hover,
+    &:focus {
+      background-color: darken($blue2, 5%);
+    }
+
+    &:active {
+      background-color: darken($blue2, 10%);
+    }
+  }
+
+  .share-donation-links {
+    padding: 0;
+
+    li {
+      display: inline-block;
+      margin: 0 10px;
+
+      .share-donation-link {
+        display: block;
+        cursor: pointer;
+        pointer-events: auto;
+
+        img {
+          pointer-events: none;
+        }
+      }
+    }
+  }
 }

--- a/src/components/page-donate/page-donate.tsx
+++ b/src/components/page-donate/page-donate.tsx
@@ -86,25 +86,21 @@ export class PageDonate {
     const shareUrl = 'https://polls.pizza/donate'; // add URL tracking parameters here, if desired
 
     // Native sharing on device via `navigator.share` - supported on mobile, tablets, and some browsers
-    const nativeShare = () => {
-      if (!navigator.share) {
+    const nativeShare = async () => {
+      if (!navigator || !navigator.share) {
         this.canNativeShare = false
         return
       }
-      navigator.share({
-          title: shareText,
-          text: shareText,
-          url: shareUrl,
-      })
-      .then(() => {
-          // Do something after successful native share (show thanks, etc.)
-      })
-      .catch((error) => {
-        console.log('Sharing failed', error)
-      })
-      .finally(() => {
-          // Do something after native sharing finished or error
-      });
+
+      try {
+        await navigator.share({
+            title: shareText,
+            text: shareText,
+            url: shareUrl,
+        });
+      } catch (error) {
+          console.log('Sharing failed', error);
+      }
     };
 
     // Fallback if native sharing is not available

--- a/src/components/page-donate/page-donate.tsx
+++ b/src/components/page-donate/page-donate.tsx
@@ -16,6 +16,7 @@ interface Token {
 export class PageDonate {
   @State() private amount?: number | null;
   @State() private showConfirmation: boolean = false;
+  @State() private canNativeShare: boolean = false;
 
   public componentWillLoad() {
     document.title = `Donate | Pizza to the Polls`;
@@ -51,6 +52,9 @@ export class PageDonate {
         locale: "auto",
         token: tokenHandler,
       });
+
+      // Determine if `navigator.share` is supported in browser (native device sharing)
+      this.canNativeShare = navigator && navigator.share ? false : true;
     }
 
     const getAmount = (): number | null => {
@@ -75,6 +79,52 @@ export class PageDonate {
         });
       }
       e.preventDefault();
+    };
+
+    // Donation Sharing
+    const shareText = 'I just donated' + (this.amount ? ' $' + this.amount : '') + ' to Pizza to the Polls to help keep Democracy Delicious this year - you should too! #democracyisdelicious';
+    const shareUrl = 'https://polls.pizza/donate'; // add URL tracking parameters here, if desired
+
+    // Native sharing on device via `navigator.share` - supported on mobile, tablets, and some browsers
+    const nativeShare = () => {
+      if (!navigator.share) {
+        this.canNativeShare = false
+        return
+      }
+      navigator.share({
+          title: shareText,
+          text: shareText,
+          url: shareUrl,
+      })
+      .then(() => {
+          // Do something after successful native share (show thanks, etc.)
+      })
+      .catch((error) => {
+        console.log('Sharing failed', error)
+      })
+      .finally(() => {
+          // Do something after native sharing finished or error
+      });
+    };
+
+    // Fallback if native sharing is not available
+    let metaDescription = document.querySelector("meta[name='description']");
+    let shareDescription = '';
+    if (metaDescription) {
+        shareDescription = metaDescription.getAttribute('content') || '';
+    }
+
+    const shareTwitterLink = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${shareUrl}&via=PizzaToThePolls`;
+
+    const shareFacebookLink = `https://www.facebook.com/sharer/sharer.php?u=${shareUrl}&title=${encodeURIComponent(shareText)}&description=${encodeURIComponent(shareDescription)}&quote=${encodeURIComponent(shareText)}`;
+
+    const openSharePopup = (e: Event) => {
+      e.preventDefault();
+      const linkTarget = e.target as HTMLLinkElement;
+      const shareUrl = linkTarget.getAttribute('href');
+      if (!shareUrl) { return }
+      window.open(shareUrl, 'popup', 'width=600,height=600');
+      return
     };
 
     return (
@@ -131,10 +181,32 @@ export class PageDonate {
                 Donate
               </button>
             </form>
+
             <div id="donate-confirmation" class="message" hidden={!this.showConfirmation}>
-              <h3>Thanks for helping make the pizza magic happen!</h3>
-              <p>Thanks for donating ${this.amount} to Pizza to the Polls. You'll receive a receipt in your email soon.</p>
+              <h3>Thanks for helping make the pizza magic&nbsp;happen!</h3>
+              <p>Thanks for donating ${this.amount} to Pizza to the Polls. You'll receive a receipt in your email&nbsp;soon.</p>
+
+              <p>Help spread the word by sharing your donation!</p>
+
+              <button id="share-donation" onClick={nativeShare} class="button" hidden={this.canNativeShare}>Share your donation</button>
+
+              <div hidden={!this.canNativeShare}>
+                <ul class="share-donation-links">
+                  <li>
+                    <a class="share-donation-link" href={shareTwitterLink} rel="noopener noreferrer" target="popup" onClick={openSharePopup} title="Share to Twitter">
+                      <img alt="Twitter" src="/images/twitter.svg"/>
+                    </a>
+                  </li>
+                  <li>
+                    <a class="share-donation-link" href={shareFacebookLink} rel="noopener noreferrer" target="popup" onClick={openSharePopup} title="Share to Facebook">
+                      <img alt="Facebook" src="/images/facebook.svg"/>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
             </div>
+
           </div>
         </div>
       </Host>

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <title>Pizza to the Polls</title>
     <link rel="icon" type="image/png" href="/images/favicons/favicon.ico" />
     <meta
-      name="Description"
+      name="description"
       content="Pizza to the Polls is making democracy delicious by delivering free food for all to polling places with long lines. Send us reports of long lines and we'll send in the delicious reinforcements."
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />


### PR DESCRIPTION
- Adds Share Donation CTA under donation confirmation. Uses `navigator.share` when available (mobile, tablet, some browsers), otherwise falls back to Facebook and Twitter share links.
- Fixes case of meta description tag