### PR TITLE
Only show native sharing if supported and viewport is <= 769px

### DIFF
--- a/src/components/app-root/app-root.scss
+++ b/src/components/app-root/app-root.scss
@@ -144,8 +144,7 @@ img {
   clear: both;
 }
 
-[hidden],
-.is-hidden {
+[hidden] {
   display: none;
 }
 

--- a/src/components/app-root/app-root.scss
+++ b/src/components/app-root/app-root.scss
@@ -144,7 +144,8 @@ img {
   clear: both;
 }
 
-[hidden] {
+[hidden],
+.is-hidden {
   display: none;
 }
 

--- a/src/components/page-donate/page-donate.scss
+++ b/src/components/page-donate/page-donate.scss
@@ -112,6 +112,7 @@ page-donate {
     background-color: $blue2;
     border: 2px solid $blue2;
     font-size: 18px;
+
     // Always hide (regardless of support) if not on mobile
     @media (min-width: 769px) {
       display: none;
@@ -119,6 +120,10 @@ page-donate {
 
     @media (min-width: 769px) {
       width: auto;
+    }
+
+    &.is-hidden {
+      display: none !important;
     }
 
     &:hover,

--- a/src/components/page-donate/page-donate.scss
+++ b/src/components/page-donate/page-donate.scss
@@ -112,6 +112,10 @@ page-donate {
     background-color: $blue2;
     border: 2px solid $blue2;
     font-size: 18px;
+    // Always hide (regardless of support) if not on mobile
+    @media (min-width: 769px) {
+      display: none;
+    }
 
     @media (min-width: 769px) {
       width: auto;
@@ -152,6 +156,17 @@ page-donate {
       @media (min-width: 769px) {
         float: left;
         top: auto;
+      }
+    }
+  }
+
+  .share-donation-link-container {
+    &.can-native-share {
+      // Hide on mobile if native sharing is supported
+      display: none;
+      // Show if not on mobile regardless
+      @media (min-width: 769px) {
+        display: block;
       }
     }
   }

--- a/src/components/page-donate/page-donate.tsx
+++ b/src/components/page-donate/page-donate.tsx
@@ -194,12 +194,12 @@ export class PageDonate {
 
               <p>Help spread the word by sharing your donation!</p>
 
-              <button id="share-donation" onClick={nativeShare} class="button" hidden={!this.canNativeShare}>
+              <button id="share-donation" onClick={nativeShare} class={`button ${this.canNativeShare ? null : "is-hidden"}`}>
                 <img alt="Share" src="/images/share.svg" />
                 <span>Share your donation!</span>
               </button>
 
-              <div hidden={this.canNativeShare}>
+              <div class={`share-donation-link-container ${this.canNativeShare ? "can-native-share" : null}`}>
                 <ul class="share-donation-links">
                   <li>
                     <a class="share-donation-link twitter" href={shareTwitterLink} rel="noopener noreferrer" target="popup" onClick={openSharePopup} title="Share to Twitter">

--- a/src/components/page-donate/page-donate.tsx
+++ b/src/components/page-donate/page-donate.tsx
@@ -199,7 +199,7 @@ export class PageDonate {
                 <span>Share your donation!</span>
               </button>
 
-              <div class={`share-donation-link-container ${this.canNativeShare ? "can-native-share" : null}`}>
+              <div class={`share-donation-link-container ${this.canNativeShare ? "can-native-share" : ""}`}>
                 <ul class="share-donation-links">
                   <li>
                     <a class="share-donation-link twitter" href={shareTwitterLink} rel="noopener noreferrer" target="popup" onClick={openSharePopup} title="Share to Twitter">


### PR DESCRIPTION
Shouldn't show native sharing on larger viewports since a laptop/desktop likely doesn't have native social apps (other than email).