### PR TITLE
URL RegEx Update and style tweaks

### DIFF
--- a/src/components/page-activity/page-activity.scss
+++ b/src/components/page-activity/page-activity.scss
@@ -14,6 +14,10 @@ page-activity {
     padding: 10px 15px;
     border-top-right-radius: $radius;
     border-top-left-radius: $radius;
+
+    @media ($under-tablet) {
+      font-size: 1em;
+    }
   }
 
   .order-list {
@@ -31,6 +35,7 @@ page-activity {
 
     > li {
       font-size: 16px;
+      line-height: 1.3;
 
       &:first-of-type {
         margin-top: 1rem;

--- a/src/components/page-donate/page-donate.scss
+++ b/src/components/page-donate/page-donate.scss
@@ -23,7 +23,7 @@ page-donate {
   }
 
   .donation-intro {
-    font-size: 14px;
+    font-size: 16px;
     font-weight: 600;
   }
 

--- a/src/components/page-report/page-report.tsx
+++ b/src/components/page-report/page-report.tsx
@@ -3,8 +3,8 @@ import { Build, Component, h, Host, State } from "@stencil/core";
 import { baseFetch } from "../../lib/base";
 
 // Shared with pizzabase
-const URL_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/;
-// const EMAIL_REGEX = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
+const URL_REGEX = /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})).?)(?::\d{2,5})?(?:[/?#]\S*)?$/i;
+const EMAIL_REGEX = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 const PHONE_REGEX = /^[+]?(1\-|1\s|1|\d{3}\-|\d{3}\s|)?((\(\d{3}\))|\d{3})(\-|\s)?(\d{3})(\-|\s)?(\d{4})$/;
 
 const scrollPageToTop = () => {
@@ -337,7 +337,8 @@ export class PageDonate {
         if (!data.url.includes("http") && !data.url.match(/\s/)) {
           data.url = `http://${data.url}`;
         }
-        if (!data.url.match(URL_REGEX)) {
+        // Ensure url is valid, and not an email address
+        if (!data.url.match(URL_REGEX) || !!data.url.match(EMAIL_REGEX)) {
           this.submitError.url = "Whoops! Can you add a link to a report of a long line - with a publicly accessible photo - so we can verify this is on the level?";
         }
       } else if (this.reportType === "photo") {

--- a/src/components/page-report/page-report.tsx
+++ b/src/components/page-report/page-report.tsx
@@ -332,8 +332,8 @@ export class PageDonate {
       }
 
       if (this.reportType === "social") {
-        // Set data.url for report (social)
-        data.url = (data.url || "").replace(/<[^>]*>/g, "");
+        // Set data.url for report (social), and trim leading/trailing white space
+        data.url = (data.url || "").replace(/<[^>]*>/g, "").trim();
         if (!data.url.includes("http") && !data.url.match(/\s/)) {
           data.url = `http://${data.url}`;
         }


### PR DESCRIPTION
This accounts for the following:

- Trims leading/trailing whitespace from URL
- Ensures URL is valid (has a dot, http(s), etc.)
- Ensures URL is not an email address
- Matches the logic [in the PR](https://github.com/pizza-to-the-polls/pizzabase/pull/14) at `pizzabase`
- Can test on `next`, or, I have a CodePen up and running: https://codepen.io/adamdehaven/pen/XWKMbxL

**This PR and `pizzabase` should be merged at the same time to ensure logic matches on front/back end.**

---

Test URLs:

```
https://www.facebook.com/777160768/posts/10159452217830769/
https://polls.pizza/uploads/new-york-ny-6150ebfd.jpg
http://twitter
http://twitter.
https://twitter.c
https://twitter.com
https://twitter.network
twitter.com
http://linkedin.com/#modal/image
test@example
test@example.com
```