### PR TITLE
Enable donate button on input event of custom amount input

### DIFF
--- a/src/components/page-donate/page-donate.tsx
+++ b/src/components/page-donate/page-donate.tsx
@@ -229,7 +229,7 @@ export class PageDonate {
                           <span class="label-text" id="custom-amount-text">
                             Other: $
                           </span>
-                          <input class="input" type="text" name="amount" id="custom-amount" autocomplete="off" />
+                          <input class="input" type="text" name="amount" id="custom-amount" onInput={handleChange} autocomplete="off" />
                           <span class="indicator"></span>
                         </label>
                       </li>


### PR DESCRIPTION
The input field wasn't detecting `onInput`, only `form.onChange`. Tested on next and verified by me & Kyle.