### PR TITLE
Fix report route redirect (to also fix /instructions and /guidelines routes)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
       BUGSNAG_KEY: ${{ secrets.BUGSNAG_KEY }}
+      ROOT_URL: https://polls.pizza
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+      BUGSNAG_KEY: ${{ secrets.BUGSNAG_KEY }}
+      ROOT_URL: https://next.polls.pizza
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
-      BUGSNAG_KEY: ${{ secrets.BUGSNAG_KEY }}
-      ROOT_URL: https://next.polls.pizza
-
     steps:
       - uses: actions/checkout@v2
 
@@ -33,6 +27,28 @@ jobs:
 
       - name: run tests
         run: npm run test
+
+  build:
+    runs-on: ubuntu-latest
+
+    needs: test
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+      BUGSNAG_KEY: ${{ secrets.BUGSNAG_KEY }}
+      ROOT_URL: https://next.polls.pizza
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v1.4.3
+        with:
+          node-version: 12
+
+      - name: install dependencies
+        run: npm install
 
       - name: build site
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "stencil build --dev --watch --serve",
     "build": "npm run clean && npm run lint && stencil build --prod --no-cache --prerender",
-    "bugsnag": "bugsnag-sourcemaps upload --api-key $BUGSNAG_KEY --directory dist/www --overwrite",
+    "bugsnag": "bugsnag-sourcemaps upload --api-key $BUGSNAG_KEY --directory dist/www --overwrite --project-root $ROOT_URL --debug",
     "clean": "rimraf dist/www",
     "start": "npm run dev",
     "fix": "npm run prettier:fix && npm run lint:fix",

--- a/src/components/app-root/app-root.tsx
+++ b/src/components/app-root/app-root.tsx
@@ -1,17 +1,17 @@
-import { Component, h, Host, State } from "@stencil/core";
+import { Component, h, Host, State } from "@stencil/core"
 
 // Debounce function for back-to-top scroll event
-const debounce = <F extends (...args: any[]) => any>(func: F, waitFor: number) => {
-  let timeout: ReturnType<typeof setTimeout> | null = null;
+const debounce = <F extends (...args: any[]) => any> (func: F, waitFor: number) => {
+  let timeout: ReturnType<typeof setTimeout> | null = null
   const debounced = (...args: Parameters<F>) => {
     if (timeout !== null) {
-      clearTimeout(timeout);
-      timeout = null;
+      clearTimeout(timeout)
+      timeout = null
     }
-    timeout = setTimeout(() => func(...args), waitFor);
-  };
-  return debounced as (...args: Parameters<F>) => ReturnType<F>;
-};
+    timeout = setTimeout(() => func(...args), waitFor)
+  }
+  return debounced as (...args: Parameters<F>) => ReturnType<F>
+}
 
 @Component({
   tag: "app-root",
@@ -23,47 +23,47 @@ export class AppRoot {
   @State() private longPageThreshold: number = 2200;
   @State() private showBackToTop: boolean = false;
 
-  public render() {
+  public render () {
     const getScrollTop = () => {
       // Determine if long page
       if (document.body.scrollHeight || document.documentElement.scrollHeight) {
-        this.showBackToTop = Math.max(document.body.scrollHeight || 0, document.documentElement.scrollTop || 0) > this.longPageThreshold;
+        this.showBackToTop = Math.max(document.body.scrollHeight || 0, document.documentElement.scrollTop || 0) > this.longPageThreshold
       } else {
-        this.showBackToTop = false;
+        this.showBackToTop = false
       }
       // Get offset
-      return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
-    };
+      return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0
+    }
 
-    this.scrollTop = getScrollTop();
+    this.scrollTop = getScrollTop()
     if (window) {
       window.addEventListener(
         "scroll",
         debounce(() => {
-          this.scrollTop = getScrollTop();
+          this.scrollTop = getScrollTop()
         }, 200),
-      );
+      )
     }
 
     const scrollBackToTop = (e?: Event) => {
       e?.preventDefault();
-      (e?.target as HTMLElement)?.blur();
+      (e?.target as HTMLElement)?.blur()
       if (window) {
         // Scroll to top
-        window.scrollTo({ top: 0, behavior: "smooth" });
-        this.scrollTop = 0;
+        window.scrollTo({ top: 0, behavior: "smooth" })
+        this.scrollTop = 0
       }
-    };
+    }
 
     return (
       <Host>
         <header class="header">
-          <stencil-route-link url="/" exact={true}>
+          <stencil-route-link url="/" exact={ true }>
             <img src="/images/lockup.png" alt="Pizza to the Polls" />
           </stencil-route-link>
           <ul class="menu" id="menu">
             <li>
-              <stencil-route-link url="/" exact={true}>
+              <stencil-route-link url="/" exact={ true }>
                 Report
               </stencil-route-link>
             </li>
@@ -86,8 +86,8 @@ export class AppRoot {
 
         <main>
           <stencil-router>
-            <stencil-route-switch scrollTopOffset={1}>
-              <stencil-route url="/" component="page-home" exact={true} />
+            <stencil-route-switch scrollTopOffset={ 1 }>
+              <stencil-route url="/" component="page-home" exact={ true } />
               <stencil-route url="/about" component="page-about" />
               <stencil-route url="/activity" component="page-activity" />
               <stencil-route url="/covid" component="page-covid" />
@@ -100,9 +100,7 @@ export class AppRoot {
               <stencil-route url="/partners" component="page-partners" />
               <stencil-route url="/press" component="page-press" />
               <stencil-route url="/privacy" component="page-privacy" />
-              <stencil-route url="/report">
-                <stencil-router-redirect url="/" />
-              </stencil-route>
+              {/* <stencil-route url="/report" component="page-report" /> */ }
               <stencil-route url="/trucks" component="page-trucks" />
               <stencil-route component="page-home" />
             </stencil-route-switch>
@@ -113,12 +111,12 @@ export class AppRoot {
           <div class="container">
             <div
               class="clearfix"
-              style={{
+              style={ {
                 clear: "left",
                 width: "100%",
                 maxWidth: "500px",
                 margin: "0 auto 40px auto",
-              }}
+              } }
             >
               <form
                 action="https://pizza.us14.list-manage.com/subscribe/post?u=ff4b828d01c30e7ef1de2e24b&amp;id=a2d940b77b"
@@ -128,7 +126,7 @@ export class AppRoot {
                 noValidate
               >
                 <ui-single-input label="Sign up for updates" buttonLabel="Sign up" type="email" name="EMAIL" placeholder="Your email address">
-                  <div style={{ position: "absolute", left: "-5000px" }} aria-hidden="true">
+                  <div style={ { position: "absolute", left: "-5000px" } } aria-hidden="true">
                     <input type="text" name="b_ff4b828d01c30e7ef1de2e24b_a2d940b77b" tabindex="-1" value="" readOnly />
                   </div>
                 </ui-single-input>
@@ -184,9 +182,9 @@ export class AppRoot {
           </div>
         </footer>
         {this.scrollTop > this.scrollTopThreshold && this.showBackToTop && (
-          <span onClick={scrollBackToTop} class={"back-to-top " + (this.scrollTop > this.scrollTopThreshold && this.showBackToTop ? "is-active" : "")} title="Back to top"></span>
-        )}
+          <span onClick={ scrollBackToTop } class={ "back-to-top " + (this.scrollTop > this.scrollTopThreshold && this.showBackToTop ? "is-active" : "") } title="Back to top"></span>
+        ) }
       </Host>
-    );
+    )
   }
 }

--- a/src/components/app-root/app-root.tsx
+++ b/src/components/app-root/app-root.tsx
@@ -100,7 +100,7 @@ export class AppRoot {
               <stencil-route url="/partners" component="page-partners" />
               <stencil-route url="/press" component="page-press" />
               <stencil-route url="/privacy" component="page-privacy" />
-              <stencil-route url="/report" component="page-report" />
+              <stencil-route url="/report" routeRender={() => <stencil-router-redirect url="/" />} />
               <stencil-route url="/trucks" component="page-trucks" />
               <stencil-route component="page-home" />
             </stencil-route-switch>

--- a/src/components/app-root/app-root.tsx
+++ b/src/components/app-root/app-root.tsx
@@ -1,17 +1,17 @@
-import { Component, h, Host, State } from "@stencil/core"
+import { Component, h, Host, State } from "@stencil/core";
 
 // Debounce function for back-to-top scroll event
-const debounce = <F extends (...args: any[]) => any> (func: F, waitFor: number) => {
-  let timeout: ReturnType<typeof setTimeout> | null = null
+const debounce = <F extends (...args: any[]) => any>(func: F, waitFor: number) => {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
   const debounced = (...args: Parameters<F>) => {
     if (timeout !== null) {
-      clearTimeout(timeout)
-      timeout = null
+      clearTimeout(timeout);
+      timeout = null;
     }
-    timeout = setTimeout(() => func(...args), waitFor)
-  }
-  return debounced as (...args: Parameters<F>) => ReturnType<F>
-}
+    timeout = setTimeout(() => func(...args), waitFor);
+  };
+  return debounced as (...args: Parameters<F>) => ReturnType<F>;
+};
 
 @Component({
   tag: "app-root",
@@ -23,47 +23,47 @@ export class AppRoot {
   @State() private longPageThreshold: number = 2200;
   @State() private showBackToTop: boolean = false;
 
-  public render () {
+  public render() {
     const getScrollTop = () => {
       // Determine if long page
       if (document.body.scrollHeight || document.documentElement.scrollHeight) {
-        this.showBackToTop = Math.max(document.body.scrollHeight || 0, document.documentElement.scrollTop || 0) > this.longPageThreshold
+        this.showBackToTop = Math.max(document.body.scrollHeight || 0, document.documentElement.scrollTop || 0) > this.longPageThreshold;
       } else {
-        this.showBackToTop = false
+        this.showBackToTop = false;
       }
       // Get offset
-      return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0
-    }
+      return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+    };
 
-    this.scrollTop = getScrollTop()
+    this.scrollTop = getScrollTop();
     if (window) {
       window.addEventListener(
         "scroll",
         debounce(() => {
-          this.scrollTop = getScrollTop()
+          this.scrollTop = getScrollTop();
         }, 200),
-      )
+      );
     }
 
     const scrollBackToTop = (e?: Event) => {
       e?.preventDefault();
-      (e?.target as HTMLElement)?.blur()
+      (e?.target as HTMLElement)?.blur();
       if (window) {
         // Scroll to top
-        window.scrollTo({ top: 0, behavior: "smooth" })
-        this.scrollTop = 0
+        window.scrollTo({ top: 0, behavior: "smooth" });
+        this.scrollTop = 0;
       }
-    }
+    };
 
     return (
       <Host>
         <header class="header">
-          <stencil-route-link url="/" exact={ true }>
+          <stencil-route-link url="/" exact={true}>
             <img src="/images/lockup.png" alt="Pizza to the Polls" />
           </stencil-route-link>
           <ul class="menu" id="menu">
             <li>
-              <stencil-route-link url="/" exact={ true }>
+              <stencil-route-link url="/" exact={true}>
                 Report
               </stencil-route-link>
             </li>
@@ -86,8 +86,8 @@ export class AppRoot {
 
         <main>
           <stencil-router>
-            <stencil-route-switch scrollTopOffset={ 1 }>
-              <stencil-route url="/" component="page-home" exact={ true } />
+            <stencil-route-switch scrollTopOffset={1}>
+              <stencil-route url="/" component="page-home" exact={true} />
               <stencil-route url="/about" component="page-about" />
               <stencil-route url="/activity" component="page-activity" />
               <stencil-route url="/covid" component="page-covid" />
@@ -100,7 +100,7 @@ export class AppRoot {
               <stencil-route url="/partners" component="page-partners" />
               <stencil-route url="/press" component="page-press" />
               <stencil-route url="/privacy" component="page-privacy" />
-              {/* <stencil-route url="/report" component="page-report" /> */ }
+              <stencil-route url="/report" component="page-report" />
               <stencil-route url="/trucks" component="page-trucks" />
               <stencil-route component="page-home" />
             </stencil-route-switch>
@@ -111,12 +111,12 @@ export class AppRoot {
           <div class="container">
             <div
               class="clearfix"
-              style={ {
+              style={{
                 clear: "left",
                 width: "100%",
                 maxWidth: "500px",
                 margin: "0 auto 40px auto",
-              } }
+              }}
             >
               <form
                 action="https://pizza.us14.list-manage.com/subscribe/post?u=ff4b828d01c30e7ef1de2e24b&amp;id=a2d940b77b"
@@ -126,7 +126,7 @@ export class AppRoot {
                 noValidate
               >
                 <ui-single-input label="Sign up for updates" buttonLabel="Sign up" type="email" name="EMAIL" placeholder="Your email address">
-                  <div style={ { position: "absolute", left: "-5000px" } } aria-hidden="true">
+                  <div style={{ position: "absolute", left: "-5000px" }} aria-hidden="true">
                     <input type="text" name="b_ff4b828d01c30e7ef1de2e24b_a2d940b77b" tabindex="-1" value="" readOnly />
                   </div>
                 </ui-single-input>
@@ -182,9 +182,9 @@ export class AppRoot {
           </div>
         </footer>
         {this.scrollTop > this.scrollTopThreshold && this.showBackToTop && (
-          <span onClick={ scrollBackToTop } class={ "back-to-top " + (this.scrollTop > this.scrollTopThreshold && this.showBackToTop ? "is-active" : "") } title="Back to top"></span>
-        ) }
+          <span onClick={scrollBackToTop} class={"back-to-top " + (this.scrollTop > this.scrollTopThreshold && this.showBackToTop ? "is-active" : "")} title="Back to top"></span>
+        )}
       </Host>
-    )
+    );
   }
 }

--- a/src/components/page-report/page-report.tsx
+++ b/src/components/page-report/page-report.tsx
@@ -1,15 +1,25 @@
-import { Component, h } from "@stencil/core";
+import { Component, h, Host } from "@stencil/core";
 
 @Component({
   tag: "page-report",
   styleUrl: "page-report.scss",
 })
-export class PageDonate {
+export class PageReport {
   public componentWillLoad() {
     document.title = `Report | Pizza to the Polls`;
   }
 
   public render() {
-    return <stencil-router-redirect url="/"></stencil-router-redirect>;
+    return (
+      <Host>
+        <div id="report" class="report">
+          <div class="container">
+            <div class="box">
+              <form-report></form-report>
+            </div>
+          </div>
+        </div>
+      </Host>
+    );
   }
 }

--- a/src/components/page-report/page-report.tsx
+++ b/src/components/page-report/page-report.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host } from "@stencil/core";
+import { Component, h } from "@stencil/core";
 
 @Component({
   tag: "page-report",
@@ -10,16 +10,6 @@ export class PageDonate {
   }
 
   public render() {
-    return (
-      <Host>
-        <div id="report" class="report">
-          <div class="container">
-            <div class="box">
-              <form-report></form-report>
-            </div>
-          </div>
-        </div>
-      </Host>
-    );
+    return <stencil-router-redirect url="/"></stencil-router-redirect>;
   }
 }


### PR DESCRIPTION
🚨  This needs a review by someone that is more familiar with `stencil-router` than me 🚨

**Important** - this also fixes the `PageReport` component class that seems to have been renamed during a merge/rebase.