### PR TITLE
Fix line endings for Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
Enforces `lf` line endings. 

This should fix line endings for Windows users -- they may need to re-clone the repo for this to take effect.