### PR TITLE
Grab URL params from RouterHistory

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -6,6 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { LocationInfo } from "./api/types";
+import { RouterHistory } from "@stencil/router";
 export namespace Components {
     interface AppRoot {
     }
@@ -23,6 +24,7 @@ export namespace Components {
         "selectedLocation"?: LocationInfo;
     }
     interface PageDonate {
+        "history"?: RouterHistory;
     }
     interface PageGuidelines {
     }
@@ -266,6 +268,7 @@ declare namespace LocalJSX {
         "selectedLocation"?: LocationInfo;
     }
     interface PageDonate {
+        "history"?: RouterHistory;
     }
     interface PageGuidelines {
     }

--- a/src/components/form-report/form-report.scss
+++ b/src/components/form-report/form-report.scss
@@ -1,4 +1,14 @@
 form-report {
+  #form-report-component {
+    margin-top: -192px; // allow scrolling for mobile header height
+    padding-top: 192px; // allow scrolling for mobile header height
+
+    @media ($tablet) {
+      margin-top: -72px; // allow scrolling for mobile header height
+      padding-top: 72px; // allow scrolling for mobile header height
+    }
+  }
+
   #form-report {
     #form-step-2 {
       h2 {

--- a/src/components/page-donate/page-donate.tsx
+++ b/src/components/page-donate/page-donate.tsx
@@ -11,7 +11,7 @@ export class PageDonate {
   @State() private canNativeShare: boolean = false;
   @State() private referral?: string | null;
   @State() private error?: string | null;
-  @Prop() history?: RouterHistory;
+  @Prop() public history?: RouterHistory;
 
   public componentWillLoad() {
     document.title = `Donate | Pizza to the Polls`;

--- a/src/components/page-donate/page-donate.tsx
+++ b/src/components/page-donate/page-donate.tsx
@@ -1,6 +1,5 @@
-import { Build, Component, h, Host, State } from "@stencil/core";
-
-import getUrlParam from "../../util/getUrlParam";
+import { Build, Component, h, Host, Prop, State } from "@stencil/core";
+import { RouterHistory } from "@stencil/router";
 
 @Component({
   tag: "page-donate",
@@ -12,13 +11,14 @@ export class PageDonate {
   @State() private canNativeShare: boolean = false;
   @State() private referral?: string | null;
   @State() private error?: string | null;
+  @Prop() history?: RouterHistory;
 
   public componentWillLoad() {
     document.title = `Donate | Pizza to the Polls`;
-    this.referral = getUrlParam(window.location.search, "referral") || "";
+    this.referral = this.history?.location.query.referral || "";
 
-    const isPostDonate = !!getUrlParam(window.location.search, "success");
-    const amountDonatedUsd = getUrlParam(window.location.search, "amount_usd");
+    const isPostDonate = !!this.history?.location.query.success;
+    const amountDonatedUsd = this.history?.location.query.amount_usd;
     if (isPostDonate && amountDonatedUsd) {
       this.amount = parseFloat(amountDonatedUsd as string);
       this.showConfirmation = true;

--- a/src/util/getUrlParam.ts
+++ b/src/util/getUrlParam.ts
@@ -1,9 +1,0 @@
-/**
- * Return the value of a URL parameter
- * @param url String
- * @param key String
- */
-export default (url: string, key: string) => {
-  const results = new RegExp("[?&]" + key + "=([^&#]*)").exec(url);
-  return results ? decodeURI(results[1]) : null;
-};


### PR DESCRIPTION
Retrieve the URL parameters on `/donate` from `RouterHistory` instead of `window.location` 
([Source](https://github.com/ionic-team/stencil-router/wiki/Passing-data-to-routes#route-query-parameters))

Also, @ribordy, according to @noahmanger you need to change the Stripe redirect to have a slash after donate so that it looks like this `/donate/?success=true&amount_usd=20` (I believe that is on the Stripe side)