### PR TITLE
Default to user clicked

### DIFF
--- a/src/components/form-report/form-report.tsx
+++ b/src/components/form-report/form-report.tsx
@@ -58,7 +58,7 @@ export class FormReport {
   @State() private reportType: string = ""; // "social" | "photo"
   @State() private hasPhoto: boolean = false;
   @State() private photoUrl: string = "";
-  @State() private userClickedGuidelinesLink: boolean = false;
+  @State() private userClickedGuidelinesLink: boolean = true;
 
   public componentDidRender() {
     if (Build.isBrowser && google && document.getElementById("autocomplete-input")) {


### PR DESCRIPTION
Don't require a user to click by setting `userClickedGuidelinesLink` to default to true