### PR TITLE
CI: validate integration PRs and deploy only master PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
       - name: build site
         run: npm run build
         env:
+          ROOT_URL: https://next.polls.pizza
           STRIPE_PUBLIC_KEY: pk_test_ci_placeholder
           NODE_ENV: stage
           PIZZA_BASE_DOMAIN: https://base-next.polls.pizza

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,20 @@
 name: Test
 
 on:
-  push:
-    branches-ignore: [master]
+  pull_request:
+    branches:
+      - master
+      - "feature/**"
+
+permissions:
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -37,8 +42,40 @@ jobs:
   build:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
-
     needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: install dependencies
+        run: npm install
+
+      - name: build site
+        run: npm run build
+        env:
+          STRIPE_PUBLIC_KEY: pk_test_ci_placeholder
+          NODE_ENV: stage
+          PIZZA_BASE_DOMAIN: https://base-next.polls.pizza
+          BUGSNAG_KEY: ""
+
+  deploy-staging:
+    if: >-
+      github.base_ref == 'master' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    concurrency:
+      group: polls-pizza-shared-staging
+      cancel-in-progress: true
+
+    permissions:
+      contents: read
 
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
@@ -47,7 +84,9 @@ jobs:
       ROOT_URL: https://next.polls.pizza
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Change CI/deployment triggers to support integration branches and agent child PRs safely.

### New event matrix

- PR into `feature/**`: validation and production-shaped build only; no AWS credentials or staging deployment.
- Same-repository PR into `master`: validation/build followed by shared-staging S3 deployment and CloudFront invalidation.
- Push to `master`: existing production deploy workflow remains unchanged.
- Arbitrary branch pushes no longer trigger staging deployment.

### Safety details

- Workflow-level permissions default to `contents: read`.
- Staging only runs when the PR base is `master` and the head belongs to this repository.
- Dependabot does not run deployment jobs.
- Child PR builds use a non-secret Stripe test placeholder and no Bugsnag key.
- Frontend staging deployment uses `cancel-in-progress: true` so staging converges on the newest umbrella PR commit.
- Checkout is updated to a supported action version.

## Intended agent workflow

```text
agent/issue-branch -> feature/integration-branch  # validation only
feature/integration-branch -> master             # deploy shared staging
master merge                                      # production workflow
```

## Validation

- `actionlint .github/workflows/test.yml`
- YAML parser validation
- `git diff --check`

## Human review

This PR changes workflow permissions and deployment behavior and must be human-reviewed before merge.
